### PR TITLE
Downgrade AGP version to make it compatible with older versions of AS

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.0-alpha06"
+agp = "8.5.2"
 coilCompose = "2.0.0"
 converterGson = "2.9.0"
 hiltAndroidCompiler = "2.51.1"


### PR DESCRIPTION
Gist: Currently there is an issue when we attempt to compile on older versions of  AS. This stable AGP version is compatible with older versions of Android Studio